### PR TITLE
add script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,26 @@ class Foo {
 }
 ```
 
+You can also specify `scriptPath` option to add script path info:
+```js
+"plugins": [
+  ["annotate-console-log", {
+    "scriptPath": "relative"
+  }]
+]
+```
+```js
+console.log('apple')
+// =>
+console.log('foo/file.js:3:1', 'foo()', 'apple')
+```
+```js
+"scriptPath": "relative" // => foo/file.js:3:1
+"scriptPath": "filename" // => file.js:3:1
+"scriptPath": "fullpath" // => /home/user/proj/foo/file.js:3:1
+```
+
+
 ## Motivation
 
 I often get lost between many `console.log` messages. The [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/) allow you to [filter the `console` output](https://developers.google.com/web/tools/chrome-devtools/console/#filtering_the_console_output). However, you need to manually annotate each `console.log` statement with useful information for filtering.

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "precommit": "npm run test",
     "test": "NODE_ENV=development npm run lint && npm run build && mocha --compilers js:babel-register && flow"
   },
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "dependencies": {
+    "pkg-up": "^1.0.0"
+  }
 }


### PR DESCRIPTION
If you specify option `"scriptPath": true`:
```js
"plugins": [
  ["annotate-console-log", {
    "scriptPath": true
  }]
]
```
it'll add a short script path (and line number)
```js
console.log('hi')
// =>
console.log('[file.js:3]', 'foo()', 'hi')
```
If the filename was `index.js` it'll ad the parent foldername
```js
console.log('[foo/index.js:5]', 'foo()', 'hi')
```

Use `"fullScriptPath": true` to add more detailed script path info
```js
console.log('foo()', 'hi', {
  scriptColumn: 4,
  scriptLine: 9,
  scriptPath: 'relative/to/nearest/package.json/full-script-path/index.js'
})
```

fixes #1